### PR TITLE
Refactor convert() to make it unit testable

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -4,46 +4,35 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/fs"
-	"os"
+)
+
+type Direction string
+
+const (
+	unix2dos = Direction("unix2dos")
+	dos2unix = Direction("dos2unix")
 )
 
 // removeCRLF will remove the trailling carriage return and/or line feed in a byte slice if existing
 func removeCRLF(data []byte) []byte {
-	// If byte slice end with CRLF
-	if len(data) > 0 && data[len(data)-2] == '\r' && data[len(data)-1] == '\n' {
+	// If byte slice ends with CRLF
+	if len(data) > 1 && data[len(data)-2] == '\r' && data[len(data)-1] == '\n' {
 		return data[0 : len(data)-2]
 	}
 
-	// If byte slice end with LF
+	// If byte slice ends with LF
 	if len(data) > 0 && data[len(data)-1] == '\n' {
 		return data[0 : len(data)-1]
 	}
 	return data
 }
 
-// convert will open and read file ain input and convert from Unix using Line Feed (LF)
-// as newline into DOS/Windows text file by replacing the Line Feed with Carriage Return (CR)
-// and Line Feed (LF) characters (CRLF)
-func convert(file, direction string) error {
-	// Open the input file
-	in, err := os.Open(file)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer in.Close()
-
-	// Open the output file
-	out, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, fs.FileMode(mode))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer out.Close()
-
-	// Create a buffered io reader
+// convert will read from the given io.Reader and convert from Unix using Line Feed (LF)
+// as newline into DOS/Windows text by replacing the Line Feed with Carriage Return (CR)
+// and Line Feed (LF) characters (CRLF) and vice-versa
+func convert(in io.Reader, out io.Writer, direction Direction) error {
 	reader := bufio.NewReader(in)
+
 	for {
 		// Read line by line until '\n' character
 		line, err := reader.ReadBytes('\n')
@@ -51,8 +40,7 @@ func convert(file, direction string) error {
 			break
 		}
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to read bytes: %w", err)
 		}
 
 		// Remove both CR+LF and/or single LF
@@ -60,22 +48,20 @@ func convert(file, direction string) error {
 
 		switch direction {
 		// If converting from LF to CRLF, add CRLF
-		case "unix2dos":
+		case unix2dos:
 			newLine = append(newLine, '\r', '\n')
 
 		// If converting from CRLF to LF, add LF
-		case "dos2unix":
+		case dos2unix:
 			newLine = append(newLine, '\n')
 		default:
-			return fmt.Errorf("Error: unsupported direction. Must be 'unix2dos' or 'dos2unix'.")
+			return fmt.Errorf("error: unsupported direction. Must be 'unix2dos' or 'dos2unix'")
 		}
 
 		_, err = out.Write(newLine)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to write to buffer: %w", err)
 		}
-
 	}
 
 	return nil

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestRemoveCRLF(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "Empty slice",
+			args: args{data: []byte{}},
+			want: []byte{},
+		},
+		{
+			name: "One byte slice - no crlf - no lf",
+			args: args{data: []byte{'A'}},
+			want: []byte{'A'},
+		},
+		{
+			name: "One byte slice - with crlf",
+			args: args{data: []byte{'A', '\r', '\n'}},
+			want: []byte{'A'},
+		},
+		{
+			name: "One byte slice - with lf",
+			args: args{data: []byte{'A', '\n'}},
+			want: []byte{'A'},
+		},
+		{
+			name: "Multi bytes slice - no crlf - no lf",
+			args: args{data: []byte{'A', 'B', 'C'}},
+			want: []byte{'A', 'B', 'C'},
+		},
+		{
+			name: "Multi bytes slice - with crlf",
+			args: args{data: []byte{'A', 'B', 'C', '\r', '\n'}},
+			want: []byte{'A', 'B', 'C'},
+		},
+		{
+			name: "Multi bytes slice - with lf",
+			args: args{data: []byte{'A', 'B', 'C', '\n'}},
+			want: []byte{'A', 'B', 'C'},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeCRLF(tt.args.data); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeCRLF() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvert(t *testing.T) {
+	type args struct {
+		in        io.Reader
+		direction Direction
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantOut string
+		wantErr bool
+	}{
+		{
+			name:    "Empty input - dos2unix",
+			args:    args{in: new(bytes.Buffer), direction: dos2unix},
+			wantOut: "",
+			wantErr: false,
+		},
+		{
+			name:    "Empty input - unix2dos",
+			args:    args{in: new(bytes.Buffer), direction: unix2dos},
+			wantOut: "",
+			wantErr: false,
+		},
+		{
+			name:    "Non empty input - unsupported direction",
+			args:    args{in: bytes.NewBuffer([]byte("ABC\n")), direction: "unsupported"},
+			wantOut: "",
+			wantErr: true,
+		},
+		{
+			name:    "Non empty input - dos2unix - dos format",
+			args:    args{in: bytes.NewBuffer([]byte("1\r\nABC\r\n\r\nDEF\r\n")), direction: dos2unix},
+			wantOut: "1\nABC\n\nDEF\n",
+			wantErr: false,
+		},
+		{
+			name:    "Non empty input - dos2unix - unix format",
+			args:    args{in: bytes.NewBuffer([]byte("1\nABC\n\nDEF\n")), direction: dos2unix},
+			wantOut: "1\nABC\n\nDEF\n",
+			wantErr: false,
+		},
+		{
+			name:    "Non empty input - dos2unix - No EOL",
+			args:    args{in: bytes.NewBuffer([]byte("ABC")), direction: dos2unix},
+			wantOut: "",
+			wantErr: false,
+		},
+		{
+			name:    "Non empty input - unix2dos - unix format",
+			args:    args{in: bytes.NewBuffer([]byte("1\nABC\n\nDEF\n")), direction: unix2dos},
+			wantOut: "1\r\nABC\r\n\r\nDEF\r\n",
+			wantErr: false,
+		},
+		{
+			name:    "Non empty input - unix2dos - dos format",
+			args:    args{in: bytes.NewBuffer([]byte("1\r\nABC\r\n\r\nDEF\r\n")), direction: unix2dos},
+			wantOut: "1\r\nABC\r\n\r\nDEF\r\n",
+			wantErr: false,
+		},
+		{
+			name:    "Non empty input - unix2dos - No EOL",
+			args:    args{in: bytes.NewBuffer([]byte("ABC")), direction: unix2dos},
+			wantOut: "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			if err := convert(tt.args.in, out, tt.args.direction); (err != nil) != tt.wantErr {
+				t.Errorf("convert() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotOut := out.String(); gotOut != tt.wantOut {
+				t.Errorf("convert() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}

--- a/cmd/dos2unix.go
+++ b/cmd/dos2unix.go
@@ -13,13 +13,17 @@ var (
 		Short: "Convert DOS file format to Unix file format",
 		Long: `dos2unix will convert DOS/Windows files using Carriage Return and Line Feed (CRLF) as newline into Unix text file by replacing the Carriage Return Line Feed with
 Line Feed (LF) character.`,
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
-				fmt.Fprintf(os.Stderr, "Error: expected 1 argument, got %d\n", len(args))
+			in, out, err := openFiles(args[0])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
+			defer in.Close()
+			defer out.Close()
 
-			err := convert(args[0], "dos2unix")
+			err = convert(in, out, dos2unix)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+func openFiles(file string) (*os.File, *os.File, error) {
+	// Open the input file
+	in, err := os.Open(file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open input file %s for reading: %s", file, err)
+
+	}
+
+	// Open the output file
+	out, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, fs.FileMode(mode))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open output file %s for writing: %s", output, err)
+	}
+
+	return in, out, nil
+}

--- a/cmd/unix2dos.go
+++ b/cmd/unix2dos.go
@@ -13,13 +13,17 @@ var (
 		Short: "Convert Unix file format to DOS file format",
 		Long: `unix2dos will convert Unix files using Line Feed (LF) as newline into DOS/Windows text file by replacing the Line Feed with
 Carriage Return (CR) and Line Feed (LF) characters (CRLF).`,
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
-				fmt.Fprintf(os.Stderr, "Error: expected 1 argument, got %d\n", len(args))
+			in, out, err := openFiles(args[0])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
+			defer in.Close()
+			defer out.Close()
 
-			err := convert(args[0], "unix2dos")
+			err = convert(in, out, unix2dos)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)


### PR DESCRIPTION
-  Refactor `convert()` to make it unit testable
- Fix a potential panic in `removeCRLF()` when `len(data)` is 1
- Add unit tests
- Set `cobra.ExactArgs(1)`