### PR TITLE
Go version: publish with 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+        version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
   test:
     strategy:
         matrix:
-          version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+          version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
   race-condition:
     strategy:
       matrix:
-        version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+        version: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache: true
 
       - name: Run GoReleaser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /app
 
@@ -12,9 +12,6 @@ RUN CGO_ENABLED=0 go build -ldflags '-d -w -s' -o main
 
 FROM scratch
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/main /
-
-EXPOSE 8080
 
 ENTRYPOINT ["/main"]

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ docker run \
 
 ### Requirements
 
-* Golang 1.16 or higher
+* Golang 1.15 or higher
 
 ### From source with go
 
-You need a working [go](https://golang.org/doc/install) toolchain (It has been developped and tested with go >= 1.16). Refer to the official documentation for more information (or from your Linux/Mac/Windows distribution documentation to install it from your favorite package manager).
+You need a working [go](https://golang.org/doc/install) toolchain (It has been developped and tested with go >= 1.15). Refer to the official documentation for more information (or from your Linux/Mac/Windows distribution documentation to install it from your favorite package manager).
 
 ```sh
 # Clone this repository

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module lescactus/unix2dos-go
 
-go 1.16
+go 1.15
 
 require github.com/spf13/cobra v1.8.0


### PR DESCRIPTION
- Publish binary using go v1.22
- Remove unused build/expose instructions in the Dockerfile
- Run the test suite using go 1.22